### PR TITLE
chore: update release configuration for Maven Central deployment and add SNAPSHOT deployment workflow

### DIFF
--- a/.github/workflows/release-deployment.yml
+++ b/.github/workflows/release-deployment.yml
@@ -30,7 +30,19 @@ jobs:
 
       - name: Test
         run: ./gradlew test
-      
-      # This is a placeholder for future Maven Central publishing
-      # - name: Publish to Maven Central
-      #   run: ./gradlew publish
+
+      # Set up GPG for signing
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Publish to Maven Central
+      - name: Publish to Maven Central
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,5 +22,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          release-type: java
           token: ${{ steps.generate-token.outputs.token }}
+          config-file: .release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/snapshot-deployment.yml
+++ b/.github/workflows/snapshot-deployment.yml
@@ -1,0 +1,73 @@
+name: SNAPSHOT Deployment
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  check-snapshot:
+    runs-on: ubuntu-latest
+    outputs:
+      is_snapshot: ${{ steps.check-version.outputs.is_snapshot }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if version is SNAPSHOT
+        id: check-version
+        run: |
+          # Extract version from gradle.properties
+          VERSION=$(grep -oP 'version=\K[^\s]+' gradle.properties)
+          # Check if version already has -SNAPSHOT suffix
+          if [[ $VERSION == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+            echo "Current version is a SNAPSHOT version: $VERSION"
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+            echo "Current version is not a SNAPSHOT version: $VERSION"
+          fi
+
+  deploy-snapshot:
+    needs: check-snapshot
+    if: ${{ needs.check-snapshot.outputs.is_snapshot == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Test
+        run: ./gradlew test
+
+      # Set up GPG for signing
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Publish to Maven Central SNAPSHOT repository
+      - name: Publish to Maven Central SNAPSHOT repository
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          # Temporarily modify the repository URL to point to the SNAPSHOT repository
+          sed -i 's|https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/|https://s01.oss.sonatype.org/content/repositories/snapshots/|' build.gradle.kts
+          ./gradlew publish

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,16 +1,16 @@
 {
   "packages": {
     ".": {
-      "release-type": "java-kotlin",
-      "package-name": "si.pecan.upsert",
-      "changelog-path": "CHANGELOG.md",
+      "release-type": "java",
       "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
       "versioning": "default",
       "extra-files": [
         {
-          "type": "json",
-          "path": "build.gradle.kts",
-          "jsonpath": "$.version"
+          "type": "generic",
+          "path": "gradle.properties"
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -163,6 +163,157 @@ ON CONFLICT (id) DO UPDATE SET
 2. **Use Batch Operations**: When upserting multiple entities, use the `upsertAll` method to take advantage of batch operation support.
 3. **Consider Performance**: For large datasets, consider using custom methods with specific ON clauses and ignored fields to optimize performance.
 
+## Maven Central
+
+### Using the Library
+
+This library is available on Maven Central. You can add it to your project using:
+
+#### Gradle (Kotlin DSL)
+
+```kotlin
+dependencies {
+    implementation("si.pecan:upsert:0.0.1")
+}
+```
+
+#### Gradle (Groovy DSL)
+
+```groovy
+dependencies {
+    implementation 'si.pecan:upsert:0.0.1'
+}
+```
+
+#### Maven
+
+```xml
+
+<dependency>
+  <groupId>si.pecan</groupId>
+  <artifactId>upsert</artifactId>
+  <version>0.0.1</version>
+</dependency>
+```
+
+### Deploying to Maven Central
+
+If you're a contributor and need to deploy a new version to Maven Central, follow these steps:
+
+1. **Set up OSSRH Account**: Create an account on [Sonatype OSSRH](https://s01.oss.sonatype.org/).
+
+2. **Configure GPG**:
+    - Install GPG
+    - Generate a key pair: `gpg --gen-key`
+    - List keys: `gpg --list-keys`
+    - Distribute your public key: `gpg --keyserver keyserver.ubuntu.com --send-keys YOUR_KEY_ID`
+
+3. **Configure Credentials**:
+    - Edit `gradle.properties` in your project root or in your Gradle home directory
+    - Add your OSSRH credentials and GPG configuration (see the template in the project's
+      `gradle.properties`)
+    - You have two options for GPG signing:
+        - Option 1: Configure GPG key details explicitly with the three properties
+        - Option 2: Use the gpg command-line tool, which will use your default GPG key
+    - Alternatively, you can set environment variables for CI/CD environments
+
+4. **Deploy**:
+    - Run: `./gradlew publish`
+    - This will build the project, sign the artifacts, and upload them to OSSRH
+
+5. **Release**:
+    - Log in to [Sonatype OSSRH](https://s01.oss.sonatype.org/)
+    - Navigate to "Staging Repositories"
+    - Find your repository, verify the contents
+    - Close and then Release the repository
+
+For more detailed instructions, see
+the [Sonatype OSSRH Guide](https://central.sonatype.org/publish/publish-guide/).
+
+### GitHub Actions Deployment
+
+This project is configured to automatically deploy to Maven Central using GitHub Actions in two
+ways:
+
+#### Automated Versioning with Release Please
+
+This project uses [Release Please](https://github.com/googleapis/release-please) to automate version
+management and release creation. Release Please:
+
+1. Creates and maintains a release PR that:
+    - Updates the version in `gradle.properties`
+    - Updates the changelog based on conventional commit messages
+    - Keeps the PR up-to-date as new commits are pushed
+
+2. When the release PR is merged:
+    - A GitHub release is automatically created
+    - The release deployment workflow is triggered
+
+To create a new release:
+
+1. Use [conventional commits](https://www.conventionalcommits.org/) in your commit messages:
+    - `fix:` for bug fixes (patch version bump)
+    - `feat:` for new features (minor version bump)
+    - `feat!:` or `fix!:` for breaking changes (major version bump)
+    - Include `BREAKING CHANGE:` in the commit body for breaking changes
+
+2. Push your commits to the main branch
+    - Release Please will create or update a release PR
+
+3. Review and merge the release PR when ready to release
+    - This will trigger the release process automatically
+
+#### Release Deployment
+
+When a new release is created (either manually or via Release Please), the project will be deployed
+to Maven Central as a release version. To set this up:
+
+1. **Configure GitHub Secrets**:
+    - Go to your repository's Settings > Secrets and variables > Actions
+    - Add the following secrets:
+        - `OSSRH_USERNAME`: Your Sonatype OSSRH username
+        - `OSSRH_PASSWORD`: Your Sonatype OSSRH password
+        - `GPG_PRIVATE_KEY`: Your GPG private key (export with
+          `gpg --export-secret-keys --armor YOUR_KEY_ID`)
+        - `GPG_PASSPHRASE`: Your GPG key passphrase
+        - `GPG_KEY_ID`: Your GPG key ID (last 8 characters of your key ID)
+        - `REPOSITORY_BUTLER_APP_ID` and `REPOSITORY_BUTLER_PEM`: For the GitHub App used by Release
+          Please (if applicable)
+
+2. **Monitor Deployment**:
+    - The GitHub Actions workflow will automatically trigger when a release is created
+    - You can monitor the progress in the Actions tab
+    - Once completed, follow the same release process on Sonatype OSSRH as described above
+
+#### SNAPSHOT Deployment
+
+The project is also configured to automatically deploy SNAPSHOT versions to Maven Central whenever
+there is a push to the main branch and the current version is a SNAPSHOT version. This allows users
+to access the latest development version without waiting for an official release.
+
+When a push is made to the main branch:
+
+1. The workflow checks if the current version in build.gradle.kts already has a "-SNAPSHOT" suffix
+2. If it is a SNAPSHOT version, the project will be built and tested
+3. The artifacts will be signed and deployed to the Maven Central SNAPSHOT repository
+4. If it is not a SNAPSHOT version, the workflow will exit without deploying
+
+To use the SNAPSHOT version in your project:
+
+```kotlin
+repositories {
+    mavenCentral()
+    // Add the Maven Central SNAPSHOT repository
+    maven {
+        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
+dependencies {
+    implementation("si.pecan:upsert:0.0.1-SNAPSHOT")
+}
+```
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,20 @@
+# Maven Central Deployment Configuration
+# OSSRH Credentials
+# Replace with your OSSRH username and password
+# ossrhUsername=your-ossrh-username
+# ossrhPassword=your-ossrh-password
+# GPG Signing Configuration
+# Option 1: Configure GPG key details (all three properties must be set)
+# signing.keyId=your-gpg-key-id (last 8 characters of your key ID)
+# signing.password=your-gpg-key-password
+# signing.secretKeyRingFile=/path/to/your/secring.gpg
+# Option 2: Use gpg command (no properties needed, will use your default GPG key)
+# Make sure gpg is installed and configured with a default key
+# Environment Variables Alternative:
+# You can also set these as environment variables:
+# OSSRH_USERNAME, OSSRH_PASSWORD for OSSRH credentials
+# SIGNING_KEY_ID, SIGNING_PASSWORD, SIGNING_SECRET_KEY_RING_FILE for GPG signing
+# Project version - this will be updated by release-please
+#x-release-please-start-version
+version=0.0.1
+#x-release-please-end-version


### PR DESCRIPTION
This pull request includes several changes to automate the deployment process to Maven Central and improve the project's release management using GitHub Actions. The most important changes include setting up GPG for signing, configuring Release Please for automated versioning, and adding a new workflow for SNAPSHOT deployments.

## Changes to deployment workflows:

* [`.github/workflows/release-deployment.yml`](diffhunk://#diff-2b9753b30ff3aa12593637d36f869d6de0b49fe88ef5b11aaab19f09324f6726L34-R48): Added steps to set up GPG for signing and publish to Maven Central.
* [`.github/workflows/snapshot-deployment.yml`](diffhunk://#diff-ac5eceacc05512382a308253dc5664b89df95acea398fa890e119d14f323aa36R1-R73): Added a new workflow to deploy SNAPSHOT versions to Maven Central when the version has a `-SNAPSHOT` suffix.

## Configuration updates:

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L25-R27): Updated to use `config-file` and `manifest-file` for Release Please configuration.
* [`.release-please-config.json`](diffhunk://#diff-f7eaa861269fa64037f877506de445a4228230f15e9700b97a376e674ba6804bL4-R13): Updated the release type to `java` and added additional configuration options for versioning and file paths.

## Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R166-R316): Added detailed instructions for using the library, deploying to Maven Central, and configuring GitHub Actions for automated deployments.

## Additional configuration:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R1-R20): Added placeholders for OSSRH credentials and GPG signing configuration, and included versioning information for Release Please.