### PR TITLE
fix: fix release process

### DIFF
--- a/.github/workflows/release-deployment.yml
+++ b/.github/workflows/release-deployment.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  releases: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-deployment.yml` file. The change removes the `releases: write` permission from the workflow configuration.

* [`.github/workflows/release-deployment.yml`](diffhunk://#diff-2b9753b30ff3aa12593637d36f869d6de0b49fe88ef5b11aaab19f09324f6726L9): Removed the `releases: write` permission.