### PR TITLE
chore: update database driver dependencies to runtimeOnly and increment version in README.md

### DIFF
--- a/.github/workflows/release-deployment.yml
+++ b/.github/workflows/release-deployment.yml
@@ -78,3 +78,44 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
         run: ./gradlew publish --build-cache
+
+      # Generate GitHub App token
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
+          private_key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
+
+      # Update README.md with current version
+      - name: Update README.md with current version
+        id: update-readme
+        run: |
+          # Extract version from gradle.properties
+          VERSION=$(grep -oP 'version=\K[^\s]+' gradle.properties)
+
+          # Remove -SNAPSHOT suffix if present
+          RELEASE_VERSION=${VERSION%-SNAPSHOT}
+
+          # Set as output for use in subsequent steps
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+
+          # Update version in README.md
+          sed -i "s/implementation(\"io.github.mpecan:upsert:[^\"]*\")/implementation(\"io.github.mpecan:upsert:$RELEASE_VERSION\")/" README.md
+          sed -i "s/implementation 'io.github.mpecan:upsert:[^']*'/implementation 'io.github.mpecan:upsert:$RELEASE_VERSION'/" README.md
+          sed -i "s/<version>[^<]*<\/version>/<version>$RELEASE_VERSION<\/version>/" README.md
+
+      # Create Pull Request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "docs: update version in README.md to ${{ steps.update-readme.outputs.release_version }} [skip ci]"
+          title: "docs: update version in README.md to ${{ steps.update-readme.outputs.release_version }}"
+          body: |
+            This PR updates the version references in README.md to match the latest release version ${{ steps.update-readme.outputs.release_version }}.
+
+            Automated changes by GitHub Actions after release creation.
+          branch: update-readme-version
+          base: main
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upsert Repository
 
-![Maven Central Version](https://img.shields.io/maven-central/v/io.github.mpecan/upsert)
+[![Maven Central Version](https://img.shields.io/maven-central/v/io.github.mpecan/upsert)](https://central.sonatype.com/artifact/io.github.mpecan/upsert)
 
 A Spring Data JPA extension that provides upsert capabilities for repositories. This library simplifies the process of inserting or updating records in a database using Spring Data JPA.
 
@@ -175,7 +175,7 @@ This library is available on Maven Central. You can add it to your project using
 
 ```kotlin
 dependencies {
-   implementation("io.github.mpecan:upsert:0.0.1")
+    implementation("io.github.mpecan:upsert:1.0.1")
 }
 ```
 
@@ -183,7 +183,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'io.github.mpecan:upsert:0.0.1'
+    implementation 'io.github.mpecan:upsert:1.0.1'
 }
 ```
 
@@ -194,7 +194,7 @@ dependencies {
 <dependency>
   <groupId>io.github.mpecan</groupId>
   <artifactId>upsert</artifactId>
-  <version>0.0.1</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Database drivers
-    implementation("org.postgresql:postgresql")
-    implementation("com.mysql:mysql-connector-j")
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")


### PR DESCRIPTION
This pull request includes changes to automate the update of version references in the `README.md` file after a new release and to improve the documentation.

Automation of version updates:

* [`.github/workflows/release-deployment.yml`](diffhunk://#diff-2b9753b30ff3aa12593637d36f869d6de0b49fe88ef5b11aaab19f09324f6726R81-R121): Added steps to generate a GitHub App token, update the `README.md` with the current version, and create a pull request with the changes.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the Maven Central badge link to point to the artifact page on Sonatype Central.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L178-R186): Updated the version references in the dependency examples to `1.0.1`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L178-R186) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R197)