### PR TITLE
feat: add performance tests for upsert operations in MySQL and PostgreSQL

### DIFF
--- a/src/main/kotlin/io/github/mpecan/upsert/dialect/MySqlUpsertDialect.kt
+++ b/src/main/kotlin/io/github/mpecan/upsert/dialect/MySqlUpsertDialect.kt
@@ -33,7 +33,7 @@ class MySqlUpsertDialect : UpsertDialect {
 
         // Create placeholders for all entities in the batch
         val allPlaceholders = (1..batchSize).joinToString(", ") {
-            "(${valueColumns.map { column -> ":${column.name}_${it}" }.joinToString(", ")})"
+            "(${valueColumns.map { column -> ":${column.fieldName}_${it}" }.joinToString(", ")})"
         }
 
         val insertClause =

--- a/src/main/kotlin/io/github/mpecan/upsert/model/JpaUpsertModelMetadataProvider.kt
+++ b/src/main/kotlin/io/github/mpecan/upsert/model/JpaUpsertModelMetadataProvider.kt
@@ -1,6 +1,7 @@
 package io.github.mpecan.upsert.model
 
 import io.github.mpecan.upsert.dialect.ColumnInfo
+import jakarta.persistence.Column
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.PersistenceUnitUtil
 import jakarta.persistence.metamodel.Metamodel
@@ -40,8 +41,18 @@ class JpaUpsertModelMetadataProvider(
             val isGenerated = field.annotations.any { it is GeneratedValue }
             val sqlType =
                 StatementCreatorUtils.javaTypeToSqlParameterType(it.javaType)
+            val columnName = when {
+                field.annotations.any { it.javaClass == Column::class.java } -> {
+                    field.getAnnotation(Column::class.java).name
+                }
+
+                else -> {
+                    // get the column name from the field name and transform it to snake case
+                    field.name.replace(Regex("([a-z])([A-Z]+)"), "$1_$2").lowercase()
+                }
+            }
             ColumnInfo(
-                it.name,
+                columnName,
                 it.name,
                 it.javaType,
                 sqlType,

--- a/src/test/kotlin/io/github/mpecan/upsert/performance/MySqlPerformanceTest.kt
+++ b/src/test/kotlin/io/github/mpecan/upsert/performance/MySqlPerformanceTest.kt
@@ -1,0 +1,250 @@
+package io.github.mpecan.upsert.performance
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDateTime
+import kotlin.system.measureTimeMillis
+
+/**
+ * Performance tests for MySQL comparing upsert operations with Spring Data JPA saveAll operations.
+ */
+@SpringBootTest(classes = [PerformanceTestApplication::class])
+@Testcontainers
+class MySqlPerformanceTest {
+
+    private val logger = LoggerFactory.getLogger(MySqlPerformanceTest::class.java)
+
+    companion object {
+        @Container
+        @JvmStatic
+        val mysqlContainer = MySQLContainer<Nothing>("mysql:8.0").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun setProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { mysqlContainer.jdbcUrl }
+            registry.add("spring.datasource.username") { mysqlContainer.username }
+            registry.add("spring.datasource.password") { mysqlContainer.password }
+            registry.add("spring.datasource.driver-class-name") { mysqlContainer.driverClassName }
+            registry.add("spring.jpa.database-platform") { "org.hibernate.dialect.MySQL8Dialect" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+        }
+    }
+
+    @Autowired
+    private lateinit var performanceTestRepository: PerformanceTestRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeEach
+    fun setUp() {
+        try {
+            // Clear the tables before each test
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+            logger.info("Tables cleared successfully")
+        } catch (e: Exception) {
+            logger.error("Error clearing tables", e)
+            throw e
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            // Clear the tables after each test
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+            logger.info("Tables cleared successfully")
+        } catch (e: Exception) {
+            logger.error("Error clearing tables", e)
+            throw e
+        }
+    }
+
+    /**
+     * Generate a list of test entities with the given size.
+     */
+    private fun generateEntities(size: Int, startId: Long = 1): List<PerformanceTestEntity> {
+        return (startId until startId + size).map { id ->
+            PerformanceTestEntity(
+                id = id,
+                name = "Entity $id",
+                description = "Description for entity $id",
+                active = id % 2 == 0L,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+                counter = id.toInt(),
+                amount = id.toDouble(),
+                code = "CODE-$id",
+                tags = "tag1,tag2,tag3"
+            )
+        }
+    }
+
+    /**
+     * Test the performance of inserting new entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [1, 10, 100, 1000])
+    fun `test insert performance - upsert vs saveAll`(size: Int) {
+        // Generate test data
+        val entities = generateEntities(size)
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(entities)
+        }
+
+        // Clear the table
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(entities)
+        }
+
+        // Log the results
+        logger.info("Insert performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of updating existing entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [1, 10, 100, 1000])
+    fun `test update performance - upsert vs saveAll`(size: Int) {
+        // Generate and insert initial entities
+        val initialEntities = generateEntities(size)
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Generate updated entities with the same IDs
+        val updatedEntities = generateEntities(size).map { entity ->
+            entity.copy(
+                name = "Updated ${entity.name}",
+                description = "Updated ${entity.description}",
+                updatedAt = LocalDateTime.now(),
+                counter = entity.counter + 1,
+                amount = entity.amount * 2,
+                tags = "updated,tags"
+            )
+        }
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(updatedEntities)
+        }
+
+        // Clear the table and reinsert initial entities
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(updatedEntities)
+        }
+
+        // Log the results
+        logger.info("Update performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of a mix of inserting and updating entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [10, 100, 1000])
+    fun `test mixed insert-update performance - upsert vs saveAll`(size: Int) {
+        // Generate and insert half of the entities
+        val halfSize = size / 2
+        val initialEntities = generateEntities(halfSize)
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Generate a mix of new and updated entities
+        val mixedEntities = generateEntities(halfSize) + generateEntities(halfSize, halfSize + 1L)
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(mixedEntities)
+        }
+
+        // Clear the table and reinsert initial entities
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(mixedEntities)
+        }
+
+        // Log the results
+        logger.info("Mixed insert-update performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of batch operations with different batch sizes.
+     */
+    @Test
+    fun `test batch size performance impact`() {
+        val totalSize = 1000
+        val entities = generateEntities(totalSize)
+
+        // Test different batch sizes
+        val batchSizes = listOf(1, 10, 50, 100, 200, 500, 1000)
+
+        for (batchSize in batchSizes) {
+            // Clear the table
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+            // Measure time for upsert with the current batch size
+            val upsertTime = measureTimeMillis {
+                entities.chunked(batchSize).forEach { batch ->
+                    performanceTestRepository.upsertAll(batch)
+                }
+            }
+
+            // Clear the table
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+            // Measure time for saveAll with the current batch size
+            val saveAllTime = measureTimeMillis {
+                entities.chunked(batchSize).forEach { batch ->
+                    performanceTestRepository.saveAll(batch)
+                }
+            }
+
+            // Log the results
+            logger.info("Batch size performance test with batch size $batchSize:")
+            logger.info("  Upsert time: $upsertTime ms")
+            logger.info("  SaveAll time: $saveAllTime ms")
+            logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+            logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+        }
+    }
+}

--- a/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestApplication.kt
+++ b/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestApplication.kt
@@ -1,0 +1,16 @@
+package io.github.mpecan.upsert.performance
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+/**
+ * Test application for performance tests.
+ */
+@SpringBootApplication
+@EntityScan(basePackages = ["io.github.mpecan.upsert.performance", "io.github.mpecan.upsert.entity"])
+@EnableJpaRepositories(
+    basePackages = ["io.github.mpecan.upsert.performance"],
+    repositoryFactoryBeanClass = io.github.mpecan.upsert.repository.UpsertRepositoryFactoryBean::class
+)
+class PerformanceTestApplication

--- a/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestEntity.kt
+++ b/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestEntity.kt
@@ -1,0 +1,37 @@
+package io.github.mpecan.upsert.performance
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * Entity class for performance testing.
+ * This class has more fields than the basic JpaTestEntity to make it more realistic for performance testing.
+ */
+@Entity
+@Table(name = "performance_test_entity")
+data class PerformanceTestEntity(
+    @Id
+    val id: Long,
+
+    val name: String,
+
+    val description: String? = null,
+
+    val active: Boolean = true,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+
+    val counter: Int = 0,
+
+    val amount: Double = 0.0,
+
+    val code: String? = null,
+
+    val tags: String? = null
+) {
+    constructor() : this(0, "", "", true, LocalDateTime.now(), LocalDateTime.now(), 0, 0.0, "", "")
+}

--- a/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestRepository.kt
+++ b/src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestRepository.kt
@@ -1,0 +1,11 @@
+package io.github.mpecan.upsert.performance
+
+import io.github.mpecan.upsert.repository.UpsertRepository
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * Repository interface for performance testing.
+ * This interface extends both UpsertRepository (for upsert operations) and JpaRepository (for saveAll operations).
+ */
+interface PerformanceTestRepository : UpsertRepository<PerformanceTestEntity, Long>,
+    JpaRepository<PerformanceTestEntity, Long>

--- a/src/test/kotlin/io/github/mpecan/upsert/performance/PostgreSqlPerformanceTest.kt
+++ b/src/test/kotlin/io/github/mpecan/upsert/performance/PostgreSqlPerformanceTest.kt
@@ -1,0 +1,250 @@
+package io.github.mpecan.upsert.performance
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDateTime
+import kotlin.system.measureTimeMillis
+
+/**
+ * Performance tests for MySQL comparing upsert operations with Spring Data JPA saveAll operations.
+ */
+@SpringBootTest(classes = [PerformanceTestApplication::class])
+@Testcontainers
+class PostgreSqlPerformanceTest {
+
+    private val logger = LoggerFactory.getLogger(PostgreSqlPerformanceTest::class.java)
+
+    companion object {
+        @Container
+        @JvmStatic
+        val mysqlContainer = PostgreSQLContainer<Nothing>("postgres:13").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun setProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { mysqlContainer.jdbcUrl }
+            registry.add("spring.datasource.username") { mysqlContainer.username }
+            registry.add("spring.datasource.password") { mysqlContainer.password }
+            registry.add("spring.datasource.driver-class-name") { mysqlContainer.driverClassName }
+            registry.add("spring.jpa.database-platform") { "org.hibernate.dialect.PostgreSQLDialect" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+        }
+    }
+
+    @Autowired
+    private lateinit var performanceTestRepository: PerformanceTestRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeEach
+    fun setUp() {
+        try {
+            // Clear the tables before each test
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+            logger.info("Tables cleared successfully")
+        } catch (e: Exception) {
+            logger.error("Error clearing tables", e)
+            throw e
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            // Clear the tables after each test
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+            logger.info("Tables cleared successfully")
+        } catch (e: Exception) {
+            logger.error("Error clearing tables", e)
+            throw e
+        }
+    }
+
+    /**
+     * Generate a list of test entities with the given size.
+     */
+    private fun generateEntities(size: Int, startId: Long = 1): List<PerformanceTestEntity> {
+        return (startId until startId + size).map { id ->
+            PerformanceTestEntity(
+                id = id,
+                name = "Entity $id",
+                description = "Description for entity $id",
+                active = id % 2 == 0L,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+                counter = id.toInt(),
+                amount = id.toDouble(),
+                code = "CODE-$id",
+                tags = "tag1,tag2,tag3"
+            )
+        }
+    }
+
+    /**
+     * Test the performance of inserting new entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [1, 10, 100, 1000])
+    fun `test insert performance - upsert vs saveAll`(size: Int) {
+        // Generate test data
+        val entities = generateEntities(size)
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(entities)
+        }
+
+        // Clear the table
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(entities)
+        }
+
+        // Log the results
+        logger.info("Insert performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of updating existing entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [1, 10, 100, 1000])
+    fun `test update performance - upsert vs saveAll`(size: Int) {
+        // Generate and insert initial entities
+        val initialEntities = generateEntities(size)
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Generate updated entities with the same IDs
+        val updatedEntities = generateEntities(size).map { entity ->
+            entity.copy(
+                name = "Updated ${entity.name}",
+                description = "Updated ${entity.description}",
+                updatedAt = LocalDateTime.now(),
+                counter = entity.counter + 1,
+                amount = entity.amount * 2,
+                tags = "updated,tags"
+            )
+        }
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(updatedEntities)
+        }
+
+        // Clear the table and reinsert initial entities
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(updatedEntities)
+        }
+
+        // Log the results
+        logger.info("Update performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of a mix of inserting and updating entities using upsert vs. saveAll.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [10, 100, 1000])
+    fun `test mixed insert-update performance - upsert vs saveAll`(size: Int) {
+        // Generate and insert half of the entities
+        val halfSize = size / 2
+        val initialEntities = generateEntities(halfSize)
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Generate a mix of new and updated entities
+        val mixedEntities = generateEntities(halfSize) + generateEntities(halfSize, halfSize + 1L)
+
+        // Measure time for upsert
+        val upsertTime = measureTimeMillis {
+            performanceTestRepository.upsertAll(mixedEntities)
+        }
+
+        // Clear the table and reinsert initial entities
+        jdbcTemplate.execute("DELETE FROM performance_test_entity")
+        performanceTestRepository.saveAll(initialEntities)
+
+        // Measure time for saveAll
+        val saveAllTime = measureTimeMillis {
+            performanceTestRepository.saveAll(mixedEntities)
+        }
+
+        // Log the results
+        logger.info("Mixed insert-update performance test with $size entities:")
+        logger.info("  Upsert time: $upsertTime ms")
+        logger.info("  SaveAll time: $saveAllTime ms")
+        logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+        logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+    }
+
+    /**
+     * Test the performance of batch operations with different batch sizes.
+     */
+    @Test
+    fun `test batch size performance impact`() {
+        val totalSize = 1000
+        val entities = generateEntities(totalSize)
+
+        // Test different batch sizes
+        val batchSizes = listOf(1, 10, 50, 100, 200, 500, 1000)
+
+        for (batchSize in batchSizes) {
+            // Clear the table
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+            // Measure time for upsert with the current batch size
+            val upsertTime = measureTimeMillis {
+                entities.chunked(batchSize).forEach { batch ->
+                    performanceTestRepository.upsertAll(batch)
+                }
+            }
+
+            // Clear the table
+            jdbcTemplate.execute("DELETE FROM performance_test_entity")
+
+            // Measure time for saveAll with the current batch size
+            val saveAllTime = measureTimeMillis {
+                entities.chunked(batchSize).forEach { batch ->
+                    performanceTestRepository.saveAll(batch)
+                }
+            }
+
+            // Log the results
+            logger.info("Batch size performance test with batch size $batchSize:")
+            logger.info("  Upsert time: $upsertTime ms")
+            logger.info("  SaveAll time: $saveAllTime ms")
+            logger.info("  Difference: ${upsertTime - saveAllTime} ms")
+            logger.info("  Ratio: ${upsertTime.toDouble() / saveAllTime.toDouble()}")
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to improve the performance testing framework for upsert operations in MySQL and PostgreSQL. The changes include updating column name handling, adding new performance test classes, and creating a test application for performance tests.

### Performance Testing Enhancements:

* [`src/test/kotlin/io/github/mpecan/upsert/performance/MySqlPerformanceTest.kt`](diffhunk://#diff-d5464640dfae4db1bf8b732e5d9977cdea19191ee040f294b12d2c08e9b45ca9R1-R250): Added a comprehensive performance test class for MySQL that compares upsert operations with Spring Data JPA saveAll operations.
* [`src/test/kotlin/io/github/mpecan/upsert/performance/PostgreSqlPerformanceTest.kt`](diffhunk://#diff-ceb922871ae7472ab506b72c148d4e4fa81925046ebe9bbc14b0bfd7dd687bafR1-R250): Added a similar performance test class for PostgreSQL to compare upsert operations with Spring Data JPA saveAll operations.

### Test Application and Entity:

* [`src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestApplication.kt`](diffhunk://#diff-03a1d4c8992addfd4cb63c6a620e96256f4e2b802dd884412a6da66014de3235R1-R16): Created a test application configuration for performance tests, including entity scanning and enabling JPA repositories.
* [`src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestEntity.kt`](diffhunk://#diff-b587c1f928c6b5054ea7c169ccd7a3621dd85511e2718656bb50d9761f24f519R1-R37): Added a new entity class specifically designed for performance testing with additional fields.
* [`src/test/kotlin/io/github/mpecan/upsert/performance/PerformanceTestRepository.kt`](diffhunk://#diff-7ae5c60cdc4c1f02495b9b3902f60bc02cd8dcbab8088e2863d80acbdc551189R1-R11): Created a repository interface for performance testing that extends both `UpsertRepository` and `JpaRepository`.

### Column Name Handling:

* [`src/main/kotlin/io/github/mpecan/upsert/dialect/MySqlUpsertDialect.kt`](diffhunk://#diff-068cd948b899131a36ccbf0e516e60d176d005355d03563fdf17dc7425b29ea9L36-R36): Modified the placeholder generation to use `fieldName` instead of `name` for columns.
* [`src/main/kotlin/io/github/mpecan/upsert/model/JpaUpsertModelMetadataProvider.kt`](diffhunk://#diff-9a231b294ce509c85670f26e99cb2b3ee5cfacc9547a6875589baf143708eda2R4): Added logic to derive column names from the `@Column` annotation or transform field names to snake case if the annotation is not present. [[1]](diffhunk://#diff-9a231b294ce509c85670f26e99cb2b3ee5cfacc9547a6875589baf143708eda2R4) [[2]](diffhunk://#diff-9a231b294ce509c85670f26e99cb2b3ee5cfacc9547a6875589baf143708eda2R44-R55)